### PR TITLE
getting-started: Do not specify the DS when dumping

### DIFF
--- a/src/pages/getting-started/b2w2.md
+++ b/src/pages/getting-started/b2w2.md
@@ -12,10 +12,10 @@ To start, you first need to obtain a dump of the game.<br/>
 
 For this, you will need: 
 - A Pokémon Black 2 Version or Pokémon White 2 Version cartridge.
-- A modified Nintendo DS/DSi/3DS.
+- A modified Nintendo DSi/3DS.
 - [GodMode9i](https://github.com/DS-Homebrew/GodMode9i).
 
-1. Launch `GodMode9i` on your DS.
+1. Launch `GodMode9i` on your console.
 2. Ensure the game cartridge is inserted.
 3. Select the `NDS GAMECARD` option in `GodMode9i`.
 4. Press `A` (yes) to dump the ROM.

--- a/src/pages/getting-started/bw.md
+++ b/src/pages/getting-started/bw.md
@@ -12,10 +12,10 @@ To start, you first need to obtain a dump of the game.<br/>
 
 For this, you will need: 
 - A Pokémon Black Version or Pokémon White Version cartridge.
-- A modified Nintendo DS/DSi/3DS.
+- A modified Nintendo DSi/3DS.
 - [GodMode9i](https://github.com/DS-Homebrew/GodMode9i).
 
-1. Launch `GodMode9i` on your DS.
+1. Launch `GodMode9i` on your console.
 2. Ensure the game cartridge is inserted.
 3. Select the `NDS GAMECARD` option in `GodMode9i`.
 4. Press `A` (yes) to dump the ROM.

--- a/src/pages/getting-started/dp.md
+++ b/src/pages/getting-started/dp.md
@@ -12,10 +12,10 @@ To start, you first need to obtain a dump of the game.<br/>
 
 For this, you will need: 
 - A Pokémon Diamond Version or Pokémon Pearl Version cartridge.
-- A modified Nintendo DS/DSi/3DS.
+- A modified Nintendo DSi/3DS.
 - [GodMode9i](https://github.com/DS-Homebrew/GodMode9i).
 
-1. Launch `GodMode9i` on your DS.
+1. Launch `GodMode9i` on your console.
 2. Ensure the game cartridge is inserted.
 3. Select the `NDS GAMECARD` option in `GodMode9i`.
 4. Press `A` (yes) to dump the ROM.

--- a/src/pages/getting-started/hgss.md
+++ b/src/pages/getting-started/hgss.md
@@ -12,10 +12,10 @@ To start, you first need to obtain a dump of the game.<br/>
 
 For this, you will need: 
 - A Pokémon HeartGold Version or Pokémon SoulSilver Version cartridge.
-- A modified Nintendo DS/DSi/3DS.
+- A modified Nintendo DSi/3DS.
 - [GodMode9i](https://github.com/DS-Homebrew/GodMode9i).
 
-1. Launch `GodMode9i` on your DS.
+1. Launch `GodMode9i` on your console.
 2. Ensure the game cartridge is inserted.
 3. Select the `NDS GAMECARD` option in `GodMode9i`.
 4. Press `A` (yes) to dump the ROM.

--- a/src/pages/getting-started/pt.md
+++ b/src/pages/getting-started/pt.md
@@ -12,10 +12,10 @@ To start, you first need to obtain a dump of the game.<br/>
 
 For this, you will need: 
 - A Pokémon Platinum Version cartridge.
-- A modified Nintendo DS/DSi/3DS.
+- A modified Nintendo DSi/3DS.
 - [GodMode9i](https://github.com/DS-Homebrew/GodMode9i).
 
-1. Launch `GodMode9i` on your DS.
+1. Launch `GodMode9i` on your console.
 2. Ensure the game cartridge is inserted.
 3. Select the `NDS GAMECARD` option in `GodMode9i`.
 4. Press `A` (yes) to dump the ROM.


### PR DESCRIPTION
# Name of Resource
```
src/pages/getting-started/*
```

# Description

When dumping from a DS or DS Lite, GodMode9i is unable to read the DSi-Enhanced bits of the cartridge. Thus, one must run GodMode9i in DSi mode.

# Which Generation (4/5/Universal)?
universal

# Notes
Align the steps with generation 4 as well for uniformity.