### PR TITLE
Update GitHub Actions workflow for deployment

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: latest
+          node-version: '25.1.0'
           cache: yarn
           cache-dependency-path: '**/package-lock.json' 
 
@@ -42,3 +42,4 @@ jobs:
           # You can swap them out with your own user credentials.
           user_name: github-actions[bot]
           user_email: 41898282+github-actions[bot]@users.noreply.github.com
+


### PR DESCRIPTION
Reverts node version to 25.1

25.2 broke docusaurus

# Name of Resource

# Description

# Which Generation (4/5/Universal)?

# Notes
