### PR TITLE
Add CSS variables for filterable sortable table for better dark mode

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -103,8 +103,8 @@ div > button {
   padding: 0.4rem 0.8rem;
   font-size: 1rem;
   border-radius: 4px;
-  border: 1px solid var(--filterable-sortable-table-button);
-  background-color: #f0f0f0;
+  border: 1px solid #ccc;
+  background-color: var(--filterable-sortable-table-button);
   cursor: pointer;
   transition: background-color 0.2s;
 }


### PR DESCRIPTION
# Name of Resource
Better Dark Mode Styling

# Description
This fixes the filterable sortable table highlighted rows and buttons to have less egregious background colors while in dark mode. I was taking a look at the [Mapping FAQs](https://ds-pokemon-hacking.github.io/docs/generation-iv/guides/mapping/mapping_faqs/) page randomly and got flashbanged with the row highlight in dark mode. I haven't done any testing locally besides changing the css in the inspector on the main site, but from what I know about docusaurus (main developer for luminescent.team) it _should_ work.

Row Highlight Before:
<img width="991" height="131" alt="image" src="https://github.com/user-attachments/assets/ed53689d-f0f7-4a2f-bf63-5f63ee736143" />

Row Highlight After:
<img width="1048" height="173" alt="image" src="https://github.com/user-attachments/assets/72aff687-4766-4de9-9ef3-b0cf0be2bb61" />

Button Before:
<img width="187" height="95" alt="image" src="https://github.com/user-attachments/assets/ea35518a-8f33-4f8b-a81c-abe835d8ea87" />

Button After:
<img width="164" height="74" alt="image" src="https://github.com/user-attachments/assets/cf845c55-dcf9-4831-93f0-87c86ef00d6f" />

# Which Generation (4/5/Universal)?
N/A

# Notes
