### PR TITLE
Fix typo in highlighted background color variable

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -27,7 +27,7 @@
   --ifm-color-primary-lighter: #00cce4;
   --ifm-color-primary-lightest: #02e4ff;
   --ifm-background-color: #000000;
-  --filterable-sortable-table-highlighted-background-color: ##4f5459;
+  --filterable-sortable-table-highlighted-background-color: #4f5459;
   --filterable-sortable-table-button: #0000;
 }
 


### PR DESCRIPTION
# Name of Resource

# Description

Had an extra `#` that needed to be deleted.

# Which Generation (4/5/Universal)?

# Notes
