### PR TITLE
Yarn to npm fix for the docusaurus/webpack issue affecting builds

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,15 +18,14 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: '20' # go back to past for safety
-          # node-version: '25.6.2' # accourding to https://github.com/facebook/docusaurus/issues/11545#issuecomment-3562159414 this one should work too if 20 doesnt
-          cache: yarn
+          node-version: '25.1.0'
+          cache: npm
           cache-dependency-path: '**/package-lock.json' 
 
       - name: Install dependencies
-        run: yarn install --frozen-lockfile
+        run: npm ci
       - name: Build website
-        run: yarn build
+        run: npm run build
 
       # Popular action to deploy to GitHub Pages:
       # Docs: https://github.com/peaceiris/actions-gh-pages#%EF%B8%8F-docusaurus


### PR DESCRIPTION
Switch the GitHub Actions workflow from Yarn to npm-based installs/builds, restore the previously pinned Node `25.1.0` version, and align dependency caching with the committed `package-lock.json`.

**Caveat:** this took me a while of reading and testing to reproduce, obviously I'm not a coder so this isn't my forte, but I _think_ it makes sense in terms of being able to reproduce and resolve with a single specific change...so I won't yolo this PR in, in case I'm doing something that's impactful in a way I don't understand.

## Suspected root cause

The failures seem to be related to an incompatibility between certain Docusaurus and Webpack dependency versions that began surfacing in CI around mid-April. The error from the actions looks like it fits this: https://github.com/facebook/docusaurus/issues/11923

The repo itself did not appear to introduce any meaningful code/configuration changes immediately before the failures started.

Because the workflow was using Yarn without a committed `yarn.lock`, I think the CI installs were not fully "controlled" in terms of dependency versions over time and could possibly use newer dependency versions during installation.

## Testing performed

I tried (and succeeded) to replicate the same error message locally:

* The last successful commit and first failing commit were both tested locally using the same Yarn install/build commands as the GitHub Action workflow, and both built successfully. This helped rule out the MDX/content changes themselves as the direct cause of the failures.
* Builds were tested successfully under both Node `22.17.0` and Node `25.1.0`, suggesting Node `25.1.0` itself was probably not the direct cause.
* The failing dependency combination was then reproduced manually by forcing:

  * `Docusaurus 3.10.0`
  * `Webpack 5.106.x`
* This reproduced the same `ProgressPlugin` schema validation error seen in CI.
* Upgrading only Docusaurus to `3.10.1` resolved the issue while keeping the newer Webpack version.

Taken together, I think this seems to point toward dependency drift in CI rather than the repository content changes themselves.

## Why these workflow changes

### Switch from Yarn to npm

The repository already tracks `package-lock.json`, but the workflow was previously using Yarn installs/builds without a committed `yarn.lock`.

Switching to:

```yaml id="ehjywt"
npm ci
npm run build
```

means CI now installs the exact dependency versions recorded in the existing repository lockfile, helping prevent future dependency drift from introducing unexpected package combinations.

### Restore Node `25.1.0`

From what I could tell Node `25.1.0` itself was not the direct cause of the issue once dependencies were resolved consistently, so this restores the previously intended runtime version while keeping the actual workflow fix focused on deterministic dependency installs.

### Cache alignment

The workflow cache configuration has also been updated to use npm/package-lock semantics for consistency with the repository's existing package management setup.