### PR TITLE
Trainer AI constant swap bugfixes

### DIFF
--- a/docs/generation-iv/guides/battle_edits/battle_edits.md
+++ b/docs/generation-iv/guides/battle_edits/battle_edits.md
@@ -58,6 +58,7 @@ This information comes from tutorials, guides, and research shared via other mea
   - [Magnitude Move Power](#magnitude-move-power)
   - [Gyro Ball Move Power Calculation Multiplier](#gyro-ball-move-power-calculation-multiplier)
   - [Flail and Reversal Move Power](#flail-and-reversal-move-power)
+  - [Trainer AI NPC Trick Logic Bypass](#trainer-ai-npc-trick-logic-bypass)
 
 - [Weather](#weather)
   - [Hail End-of-Turn Damage for Non-Ice Types](#hail-end-of-turn-damage-for-non-ice-types)
@@ -68,7 +69,13 @@ This information comes from tutorials, guides, and research shared via other mea
 
 - [Bug Fixes](#bug-fixes)
   - [Fire Fang vs Wonder Guard](#fire-fang-vs-wonder-guard)
-  - [Trainer AI Water Immunity Check vs Dry Skin](#trainer-ai-water-immunity-check-vs-dry-skin)
+  - [Trainer AI Basic Flag Water Immunity Check vs Dry Skin](#trainer-ai-basic-flag-water-immunity-check-vs-dry-skin)
+  - [Trainer AI Basic Flag Sunny Day Check](#trainer-ai-basic-flag-sunny-day-check)
+  - [Trainer AI Expert Flag Foresight and Odor Sleuth Ghost Type Check](#trainer-ai-expert-flag-foresight-and-odor-sleuth-ghost-type-check)
+  - [Trainer AI Expert Flag Facade Status Check](#trainer-ai-expert-flag-facade-status-check)
+  - [Trainer AI Expert Flag Leaf Guard Sunny Day Logic](#trainer-ai-expert-flag-leaf-guard-sunny-day-logic)
+  - [Trainer AI Expert Flag Water Spout and Eruption HP Check](#trainer-ai-expert-flag-water-spout-and-eruption-hp-check)
+  - [Trainer AI Expert Flag Charge-Turn Move Scoring Fix](#trainer-ai-expert-flag-charge-turn-move-scoring-fix)
 
 
 ---
@@ -178,7 +185,7 @@ Here is a table of bytes and the resulting thaw chance.
 |  `01`  |          100%         |
 <br/>
 
-
+---
 
 ## Abilities
 
@@ -492,7 +499,7 @@ Rivalry **increases** the power of moves by **25%** if the target and the user h
 Rivalry **reduces** the power of moves by **25%** if the target and the user have opposite genders. The battle logic calculates the reduced damage by multiplying and dividing the move's power by explicitly defined values, in this case **75** (`4B` in hexadecimal) and **100** (`64` in hexadecimal), respectively.
 <br/>
 
-
+---
 
 ## Items
 
@@ -598,7 +605,7 @@ The item properties assigned to X Attack, X Defense, X Special, X Sp. Def, X Spe
 As an example, to change the effect to raise the Pokémon's respective state by **2 stages** (matching Gen VII onwards), change the byte from `01` to `02`.
 <br/>
 
-
+---
 
 ## Move Effects
 
@@ -825,6 +832,35 @@ Here is the table of the HP ratio (based on the vanilla multiplier of **64**) to
 
 
 
+### Trainer AI NPC Trick Logic Bypass
+> Sources and Credits: [MrHam88](https://github.com/DevHam88), [Plat Decomp](https://github.com/pret/pokeplatinum/blob/44f90af936713061fc9608b1332b2b4616d0c80f/src/battle/battle_script.c#L6347)
+
+Open the relevant file and change the byte at the provided offset:
+| Game                     | File                        | Offset    | Vanilla Byte |
+|:------------------------:|:---------------------------:|:---------:|:------------:|
+| **HeartGold/SoulSilver** | `Decompressed Overlay 12`   | `0xB1DA`  | `84`         |
+| **Platinum**             | `Decompressed Overlay 16`   | `0xAFB2`  | `84`         |
+| **Diamond/Pearl**        | `Decompressed Overlay 11`   | `0xA622`  | `84`         |
+
+<details>
+  <summary>You can also search for these bytes instead</summary>
+  |               | Vanilla Bytes                                            |
+  |:-------------:|:--------------------------------------------------------:|
+  | **All Games** | `00 28 08 D0 02 98 84 21 08 42 04 D1 20 1C 31 1C`        |
+</details>
+
+In standard battles (wild battles and normal trainer battles), held items cannot be swapped by the AI. This is an anti-griefing feature that prevents wild Pokémon or normal trainers from permanently taking the player's held items using moves like Trick or Switcheroo by ensuring the move always fails. The battle engine checks if the battle type is a Link Battle or a Battle Frontier battle using the bitmask `0x84` (`BATTLE_TYPE_LINK | BATTLE_TYPE_FRONTIER`) and only allows item swapping if this check is successful. 
+
+By modifying this bitmask to `0x85` (adding `BATTLE_TYPE_TRAINER`), we can enable NPC trainers in normal in-game battles to successfully use Trick and Switcheroo as well (while still ensuring that if the moves are used by wild Pokémon, the move fails)!
+
+> [!NOTE]
+> This edit does not implement post-battle item restoration for normal trainer battles. Any items swapped during a standard story battle will remain swapped permanently after the battle concludes.
+
+To implement this edit, change the bitmask byte from `84` to `85`.
+<br/>
+
+---
+
 ## Weather
 
 ### Hail End-of-Turn Damage for Non-Ice Types
@@ -873,7 +909,7 @@ Open the relevant file and go to the provided offset:
 At this location, the battle logic checks if the Pokémon's first type is Ice, then if the second type is Ice, then if the ability is Snow Cloak to skip applying Hail damage to the Pokémon. Replacing `16 D0` with `16 E0` at this offset changes the first check from a conditional branch to an unconditional branch, which will effectively skip applying Hail damage to all Pokémon (mirroring the Snow weather that replaces Hail in Gen IX onwards).
 <br/>
 
-
+---
 
 ## Miscellaneous
 
@@ -898,7 +934,7 @@ Here is a table of the vanilla bytes, as well as bytes that match the changes in
 
 <br/>
 
-
+---
 
 ## Bug Fixes
 
@@ -926,7 +962,7 @@ To fix the issue, change the byte from `11` to `10`.
 
 
 
-### Trainer AI Water Immunity Check vs Dry Skin
+### Trainer AI Basic Flag Water Immunity Check vs Dry Skin
 > Sources and Credits: [Memory5ty7](https://discord.com/channels/446824489045721090/920372513488404542/1216114974255091774), [DarmaniDan](https://discord.com/channels/446824489045721090/920372513488404542/1216146554646433914), [Lhea](https://discord.com/channels/446824489045721090/1201213967389966378/1210066487562207302), [Plat Decomp](https://github.com/pret/pokeplatinum/blob/44f90af936713061fc9608b1332b2b4616d0c80f/asm/trainer_ai/trainer_ai_script.s#L78C50-L78C65)
 
 Open the relevant file and change the byte at the provided offset:
@@ -946,4 +982,152 @@ Open the relevant file and change the byte at the provided offset:
 The Trainer AI performs two checks when considering whether the opposing Pokémon is immune to Water-Type moves. The first check considers Water Absorb, but the second check mistakenly considers Levitate instead of Dry Skin. In practice, this means that **(1)** a Trainer's Pokémon won't use Water-Type moves if it knows that the opposing Pokémon has Levitate, and **(2)** a Trainer's Pokémon may repeatedly use a Water-Type move against an opposing Pokémon with Dry Skin.
 
 To fix the issue, change the byte from `1A` (26 in decimal, Levitate's ID) to `57` (87 in decimal, Dry Skin's ID).
+<br/>
+
+
+
+### Trainer AI Basic Flag Sunny Day Check
+> Sources and Credits: [MrHam88](https://github.com/DevHam88), [Plat Decomp](https://github.com/pret/pokeplatinum/blob/44f90af936713061fc9608b1332b2b4616d0c80f/asm/trainer_ai/trainer_ai_script.s#L803-L816)
+
+Open the relevant file and change the byte at the provided offsets:
+| Game                     | File                        | Offset (Ability) | Vanilla Byte | Offset (Status) | Vanilla Byte |
+|:------------------------:|:---------------------------:|:----------------:|:------------:|:----------------:|:------------:|
+| **HeartGold/SoulSilver** | `Decompressed Overlay 10`   | `0x6310`         | `5D`         | `0x6318`         | `09`         |
+| **Platinum**             | `Overlay 14`                | `0x6308`         | `5D`         | `0x6310`         | `09`         |
+| **Diamond/Pearl**        | `Overlay 16`                | `0x1EFD8`        | `5D`         | `0x1EFE0`        | `09`         |
+
+<details>
+  <summary>You can also search for these bytes instead</summary>
+  |               | Vanilla Bytes                                            |
+  |:-------------:|:--------------------------------------------------------:|
+  | **All Games** | `5D 00 00 00 04 00 00 00 09 00 00 00 00 00 00 00`        |
+</details>
+
+In the Basic Trainer AI scoring for Sunny Day, the game checks if the target has Hydration and is statused (which is a copy-paste error from the Rain Dance handler). For Sunny weather, it should instead evaluate whether the opponent has Leaf Guard and is *not* statused (since Leaf Guard prevents status in Sun, making status moves useless).
+
+To fix this copy-paste bug:
+* Change the evaluated ability byte from `5D` (`ABILITY_HYDRATION`) to `66` (`ABILITY_LEAF_GUARD`).
+* Change the status check opcode byte from `09` (`IfStatus`) to `0A` (`IfStatusNot`).
+<br/>
+
+
+
+### Trainer AI Expert Flag Foresight and Odor Sleuth Ghost Type Check
+> Sources and Credits: [MrHam88](https://github.com/DevHam88), [Plat Decomp](https://github.com/pret/pokeplatinum/blob/44f90af936713061fc9608b1332b2b4616d0c80f/asm/trainer_ai/trainer_ai_script.s#L3605-L3618)
+
+Open the relevant file and change the byte at the provided offsets:
+| Game                     | File                        | Offset (Type 1) | Vanilla Byte | Offset (Type 2) | Vanilla Byte |
+|:------------------------:|:---------------------------:|:---------------:|:------------:|:---------------:|:------------:|
+| **HeartGold/SoulSilver** | `Decompressed Overlay 10`   | `0x9DD0`        | `01`         | `0x9DE4`        | `03`         |
+| **Platinum**             | `Overlay 14`                | `0x9DC8`        | `01`         | `0x9DDC`        | `03`         |
+| **Diamond/Pearl**        | `Overlay 16`                | `0x22A70`       | `01`         | `0x22A84`       | `03`         |
+
+<details>
+  <summary>You can also search for these bytes instead</summary>
+  |               | Vanilla Bytes (Type 1)                                   | Vanilla Bytes (Type 2)                                   |
+  |:-------------:|:--------------------------------------------------------:|:--------------------------------------------------------:|
+  | **All Games** | `4D 00 00 00 1E 00 00 00 01 00 00 00 13 00 00 00`        | `0E 00 00 00 1E 00 00 00 03 00 00 00 13 00 00 00`        |
+</details>
+
+When considering whether to use Foresight or Odor Sleuth to enable Normal/Fighting moves to hit Ghost-type targets, the Expert Trainer AI evaluates the *user's* typing instead of the *target's* typing. This means the AI will only attempt to use these moves if its own Pokémon is a Ghost-type, rather than when the opponent is a Ghost-type.
+
+To fix this issue, swap the source type constant bytes from user typing to target typing:
+* Change Type 1 offset from `01` (`LOAD_ATTACKER_TYPE_1`) to `00` (`LOAD_DEFENDER_TYPE_1`).
+* Change Type 2 offset from `03` (`LOAD_ATTACKER_TYPE_2`) to `02` (`LOAD_DEFENDER_TYPE_2`).
+<br/>
+
+
+
+### Trainer AI Expert Flag Facade Status Check
+> Sources and Credits: [MrHam88](https://github.com/DevHam88), [Plat Decomp](https://github.com/pret/pokeplatinum/blob/44f90af936713061fc9608b1332b2b4616d0c80f/asm/trainer_ai/trainer_ai_script.s#L4117-L4120)
+
+Open the relevant file and change the byte at the provided offset:
+| Game                     | File                        | Offset    | Vanilla Byte |
+|:------------------------:|:---------------------------:|:---------:|:------------:|
+| **HeartGold/SoulSilver** | `Decompressed Overlay 10`   | `0xA7F4`  | `00`         |
+| **Platinum**             | `Overlay 14`                | `0xA7EC`  | `00`         |
+| **Diamond/Pearl**        | `Overlay 16`                | `0x23494` | `00`         |
+
+<details>
+  <summary>You can also search for these bytes instead</summary>
+  |               | Vanilla Bytes                                            |
+  |:-------------:|:--------------------------------------------------------:|
+  | **All Games** | `4D 00 00 00 0A 00 00 00 00 00 00 00 D8 00 00 00`        |
+</details>
+
+When evaluating the move Facade, the Expert Trainer AI checks if the target has a status condition (poison, burn, paralysis) that would boost the move's power, rather than checking if the user itself is statused. As a result, the AI incorrectly rewards using Facade when the opponent is statused instead of when the AI's own Pokémon is statused.
+
+To fix this issue, change the target battler byte from `00` (target) to `01` (user).
+<br/>
+
+
+
+### Trainer AI Expert Flag Leaf Guard Sunny Day Logic
+> Sources and Credits: [MrHam88](https://github.com/DevHam88), [Plat Decomp](https://github.com/pret/pokeplatinum/blob/44f90af936713061fc9608b1332b2b4616d0c80f/asm/trainer_ai/trainer_ai_script.s#L3786-L3790)
+
+Open the relevant file and change the byte at the provided offset:
+| Game                     | File                        | Offset    | Vanilla Byte |
+|:------------------------:|:---------------------------:|:---------:|:------------:|
+| **HeartGold/SoulSilver** | `Decompressed Overlay 10`   | `0xA198`  | `09`         |
+| **Platinum**             | `Overlay 14`                | `0xA190`  | `09`         |
+| **Diamond/Pearl**        | `Overlay 16`                | `0x22E38` | `09`         |
+
+<details>
+  <summary>You can also search for these bytes instead</summary>
+  |               | Vanilla Bytes                                            |
+  |:-------------:|:--------------------------------------------------------:|
+  | **All Games** | `66 00 00 00 0C 00 00 00 09 00 00 00 01 00 00 00`        |
+</details>
+
+Under Sunny weather, the Leaf Guard ability protects a Pokémon from receiving status conditions. When scoring the move Sunny Day, the Expert Trainer AI evaluates whether its Pokémon has Leaf Guard and checks if it is *already* statused. However, the logic is inverted: it checks `IfStatus` (0x09) and awards a score bonus only if the Pokémon is already statused, rather than when it is healthy.
+
+To fix this issue, change the opcode byte from `09` (`IfStatus`) to `0A` (`IfStatusNot`).
+<br/>
+
+
+
+### Trainer AI Expert Flag Water Spout and Eruption HP Check
+> Sources and Credits: [MrHam88](https://github.com/DevHam88), [Plat Decomp](https://github.com/pret/pokeplatinum/blob/44f90af936713061fc9608b1332b2b4616d0c80f/asm/trainer_ai/trainer_ai_script.s#L4607-L4623)
+
+Open the relevant file and change the byte at the provided offsets:
+| Game                     | File                        | Offset (Faster) | Vanilla Byte | Offset (Slower) | Vanilla Byte |
+|:------------------------:|:---------------------------:|:---------------:|:------------:|:---------------:|:------------:|
+| **HeartGold/SoulSilver** | `Decompressed Overlay 10`   | `0xB110`        | `00`         | `0xB128`        | `00`         |
+| **Platinum**             | `Overlay 14`                | `0xB108`        | `00`         | `0xB120`        | `00`         |
+| **Diamond/Pearl**        | `Overlay 16`                | `0x23DB0`       | `00`         | `0x23DC8`       | `00`         |
+
+<details>
+  <summary>You can also search for these bytes instead</summary>
+  |               | Vanilla Bytes (Faster)                                   | Vanilla Bytes (Slower)                                   |
+  |:-------------:|:--------------------------------------------------------:|:--------------------------------------------------------:|
+  | **All Games** | `06 00 00 00 06 00 00 00 00 00 00 00 32 00 00 00`        | `04 00 00 00 06 00 00 00 00 00 00 00 46 00 00 00`        |
+</details>
+
+When considering whether to use Water Spout or Eruption, the Expert Trainer AI evaluates the target's HP percentage rather than its own. Since these moves deal damage proportional to the user's remaining HP, the AI will incorrectly avoid using these moves when its own Pokémon is at full HP if the target is low on health, or utilize them poorly when its own Pokémon is near fainting if the target is healthy.
+
+To fix this issue, change both target battler bytes from `00` (target) to `01` (user).
+<br/>
+
+
+
+### Trainer AI Expert Flag Charge-Turn Move Scoring Fix
+> Sources and Credits: [MrHam88](https://github.com/DevHam88), [Plat Decomp](https://github.com/pret/pokeplatinum/blob/44f90af936713061fc9608b1332b2b4616d0c80f/asm/trainer_ai/trainer_ai_script.s#L4061-L4063)
+
+Open the relevant file and change the bytes at the provided offset:
+| Game                     | File                        | Offset    | Vanilla Bytes |
+|:------------------------:|:---------------------------:|:---------:|:-------------:|
+| **HeartGold/SoulSilver** | `Decompressed Overlay 10`   | `0xA710`  | `01 00 00 00` |
+| **Platinum**             | `Overlay 14`                | `0xA708`  | `01 00 00 00` |
+| **Diamond/Pearl**        | `Overlay 16`                | `0x233B0` | `01 00 00 00` |
+
+<details>
+  <summary>You can also search for these bytes instead</summary>
+  |               | Vanilla Bytes                                            |
+  |:-------------:|:--------------------------------------------------------:|
+  | **All Games** | `4D 00 00 00 04 00 00 00 01 00 00 00 4D 00 00 00`        |
+</details>
+
+When evaluating charge-turn semi-invulnerable moves (such as Fly or Dig), the Expert Trainer AI includes logic that triggers if the opponent is immune or resistant to the move. However, instead of penalizing this move, a bug in the scoring block adds `+1` to the move score. This causes the AI to erroneously favor using Ground-type Dig against immune Flying-type opponents, or using Flying-type Fly against Electric-types.
+
+To fix the issue, change the score bonus bytes from `01 00 00 00` (+1) to `FF FF FF FF` (-1).
 <br/>

--- a/docs/generation-iv/guides/battle_edits/battle_edits.md
+++ b/docs/generation-iv/guides/battle_edits/battle_edits.md
@@ -846,7 +846,7 @@ Open the relevant file and change the byte at the provided offset:
   <summary>You can also search for these bytes instead</summary>
   |               | Vanilla Bytes                                            |
   |:-------------:|:--------------------------------------------------------:|
-  | **All Games** | `00 28 08 D0 02 98 84 21 08 42 04 D1 20 1C 31 1C`        |
+  | **All Games** | `84 21 08 42 04 D1 20 1C 31 1C 02 F0`        |
 </details>
 
 In standard battles (wild battles and normal trainer battles), held items cannot be swapped by the AI. This is an anti-griefing feature that prevents wild Pokémon or normal trainers from permanently taking the player's held items using moves like Trick or Switcheroo by ensuring the move always fails. The battle engine checks if the battle type is a Link Battle or a Battle Frontier battle using the bitmask `0x84` (`BATTLE_TYPE_LINK | BATTLE_TYPE_FRONTIER`) and only allows item swapping if this check is successful. 

--- a/docs/generation-iv/guides/battle_edits/battle_edits.md
+++ b/docs/generation-iv/guides/battle_edits/battle_edits.md
@@ -833,7 +833,7 @@ Here is the table of the HP ratio (based on the vanilla multiplier of **64**) to
 
 
 ### Bypass Trick 'Always Fail' Logic
-> Sources and Credits: [MrHam88](https://github.com/DevHam88), [Plat Decomp](https://github.com/pret/pokeplatinum/blob/44f90af936713061fc9608b1332b2b4616d0c80f/src/battle/battle_script.c#L6347)
+> Sources and Credits: [MrHam88](https://github.com/DevHam88), [Plat Decomp](https://github.com/pret/pokeplatinum/blob/3296fa8df7f09aeab1a44b12f52f4e456fce8836/src/battle/battle_script.c#L6347)
 
 Open the relevant file and change the byte at the provided offset:
 | Game                     | File                        | Offset    | Vanilla Byte |

--- a/docs/generation-iv/guides/battle_edits/battle_edits.md
+++ b/docs/generation-iv/guides/battle_edits/battle_edits.md
@@ -839,7 +839,7 @@ Open the relevant file and change the byte at the provided offset:
 | Game                     | File                        | Offset    | Vanilla Byte |
 |:------------------------:|:---------------------------:|:---------:|:------------:|
 | **HeartGold/SoulSilver** | `Decompressed Overlay 12`   | `0xB1DA`  | `84`         |
-| **Platinum**             | `Decompressed Overlay 16`   | `0xAFB2`  | `84`         |
+| **Platinum**             | `Overlay 16`   | `0xAFB2`  | `84`         |
 | **Diamond/Pearl**        | `Decompressed Overlay 11`   | `0xA622`  | `84`         |
 
 <details>

--- a/docs/generation-iv/guides/battle_edits/battle_edits.md
+++ b/docs/generation-iv/guides/battle_edits/battle_edits.md
@@ -58,7 +58,7 @@ This information comes from tutorials, guides, and research shared via other mea
   - [Magnitude Move Power](#magnitude-move-power)
   - [Gyro Ball Move Power Calculation Multiplier](#gyro-ball-move-power-calculation-multiplier)
   - [Flail and Reversal Move Power](#flail-and-reversal-move-power)
-  - [Trainer AI NPC Trick Logic Bypass](#trainer-ai-npc-trick-logic-bypass)
+  - [Bypass Trick 'Always Fail' Logic](#bypass-trick-always-fail-logic)
 
 - [Weather](#weather)
   - [Hail End-of-Turn Damage for Non-Ice Types](#hail-end-of-turn-damage-for-non-ice-types)
@@ -832,7 +832,7 @@ Here is the table of the HP ratio (based on the vanilla multiplier of **64**) to
 
 
 
-### Trainer AI NPC Trick Logic Bypass
+### Bypass Trick 'Always Fail' Logic
 > Sources and Credits: [MrHam88](https://github.com/DevHam88), [Plat Decomp](https://github.com/pret/pokeplatinum/blob/44f90af936713061fc9608b1332b2b4616d0c80f/src/battle/battle_script.c#L6347)
 
 Open the relevant file and change the byte at the provided offset:
@@ -854,7 +854,7 @@ In standard battles (wild battles and normal trainer battles), held items cannot
 By modifying this bitmask to `0x85` (adding `BATTLE_TYPE_TRAINER`), we can enable NPC trainers in normal in-game battles to successfully use Trick and Switcheroo as well (while still ensuring that if the moves are used by wild Pokémon, the move fails)!
 
 > [!NOTE]
-> This edit does not implement post-battle item restoration for normal trainer battles. Any items swapped during a standard story battle will remain swapped permanently after the battle concludes.
+> This edit does not implement post-battle item restoration for normal trainer battles. Any items swapped during a standard battle will remain swapped permanently after the battle concludes.
 
 To implement this edit, change the bitmask byte from `84` to `85`.
 <br/>
@@ -1003,7 +1003,7 @@ Open the relevant file and change the byte at the provided offsets:
   | **All Games** | `5D 00 00 00 04 00 00 00 09 00 00 00 00 00 00 00`        |
 </details>
 
-In the Basic Trainer AI scoring for Sunny Day, the game checks if the target has Hydration and is statused (which is a copy-paste error from the Rain Dance handler). For Sunny weather, it should instead evaluate whether the opponent has Leaf Guard and is *not* statused (since Leaf Guard prevents status in Sun, making status moves useless).
+In the Basic Trainer AI scoring for Sunny Day, the game checks if the target has Hydration and is statused (which is a copy-paste error from the Rain Dance handler). For Sunny weather, it should instead evaluate whether the opponent has Leaf Guard and is *not* statused (since Leaf Guard prevents status in Sun, but does not *heal* status conditions like Hydration).
 
 To fix this copy-paste bug:
 * Change the evaluated ability byte from `5D` (`ABILITY_HYDRATION`) to `66` (`ABILITY_LEAF_GUARD`).
@@ -1055,7 +1055,7 @@ Open the relevant file and change the byte at the provided offset:
   | **All Games** | `4D 00 00 00 0A 00 00 00 00 00 00 00 D8 00 00 00`        |
 </details>
 
-When evaluating the move Facade, the Expert Trainer AI checks if the target has a status condition (poison, burn, paralysis) that would boost the move's power, rather than checking if the user itself is statused. As a result, the AI incorrectly rewards using Facade when the opponent is statused instead of when the AI's own Pokémon is statused.
+When evaluating the move Facade, the Expert Trainer AI checks if the target has a status condition (poison, burn, paralysis), rather than checking if the user itself is statused (which would boost the move's power). As a result, the AI incorrectly rewards using Facade when the *opponent* is statused instead of when the AI's own Pokémon is statused.
 
 To fix this issue, change the target battler byte from `00` (target) to `01` (user).
 <br/>
@@ -1079,7 +1079,7 @@ Open the relevant file and change the byte at the provided offset:
   | **All Games** | `66 00 00 00 0C 00 00 00 09 00 00 00 01 00 00 00`        |
 </details>
 
-Under Sunny weather, the Leaf Guard ability protects a Pokémon from receiving status conditions. When scoring the move Sunny Day, the Expert Trainer AI evaluates whether its Pokémon has Leaf Guard and checks if it is *already* statused. However, the logic is inverted: it checks `IfStatus` (0x09) and awards a score bonus only if the Pokémon is already statused, rather than when it is healthy.
+Under Sunny weather, the Leaf Guard ability protects a Pokémon from receiving status conditions, but does not *heal* status conditions like Hydration. When scoring the move Sunny Day, the Expert Trainer AI evaluates whether its Pokémon has Leaf Guard and checks if it is *already* statused. However, the logic is inverted: it checks `IfStatus` (0x09) and awards a score bonus only if the Pokémon is already statused, rather than when it is healthy.
 
 To fix this issue, change the opcode byte from `09` (`IfStatus`) to `0A` (`IfStatusNot`).
 <br/>

--- a/docs/generation-iv/guides/battle_edits/battle_edits.md
+++ b/docs/generation-iv/guides/battle_edits/battle_edits.md
@@ -840,7 +840,7 @@ Open the relevant file and change the byte at the provided offset:
 |:------------------------:|:---------------------------:|:---------:|:------------:|
 | **HeartGold/SoulSilver** | `Decompressed Overlay 12`   | `0xB1DA`  | `84`         |
 | **Platinum**             | `Overlay 16`   | `0xAFB2`  | `84`         |
-| **Diamond/Pearl**        | `Decompressed Overlay 11`   | `0xA622`  | `84`         |
+| **Diamond/Pearl**        | `Overlay 11`   | `0xA622`  | `84`         |
 
 <details>
   <summary>You can also search for these bytes instead</summary>
@@ -979,7 +979,7 @@ Open the relevant file and change the byte at the provided offset:
   | **All Games** | `1A 00 00 00 26 00 00 00`  |
 </details>
 
-The Trainer AI performs two checks when considering whether the opposing Pokémon is immune to Water-Type moves. The first check considers Water Absorb, but the second check mistakenly considers Levitate instead of Dry Skin. In practice, this means that **(1)** a Trainer's Pokémon won't use Water-Type moves if it knows that the opposing Pokémon has Levitate, and **(2)** a Trainer's Pokémon may repeatedly use a Water-Type move against an opposing Pokémon with Dry Skin.
+The Basic Trainer AI performs two checks when considering whether the opposing Pokémon is immune to Water-Type moves. The first check considers Water Absorb, but the second check mistakenly considers Levitate instead of Dry Skin. In practice, this means that **(1)** a Trainer's Pokémon won't use Water-Type moves if it knows that the opposing Pokémon has Levitate, and **(2)** a Trainer's Pokémon may repeatedly use a Water-Type move against an opposing Pokémon with Dry Skin.
 
 To fix the issue, change the byte from `1A` (26 in decimal, Levitate's ID) to `57` (87 in decimal, Dry Skin's ID).
 <br/>
@@ -1000,7 +1000,7 @@ Open the relevant file and change the byte at the provided offsets:
   <summary>You can also search for these bytes instead</summary>
   |               | Vanilla Bytes                                            |
   |:-------------:|:--------------------------------------------------------:|
-  | **All Games** | `5D 00 00 00 04 00 00 00 09 00 00 00 00 00 00 00`        |
+  | **All Games** | `5D 00 00 00 04 00 00 00 09 00 00 00 00 00 00 00 FF 00 00 00 33 04 00 00`        |
 </details>
 
 In the Basic Trainer AI scoring for Sunny Day, the game checks if the target has Hydration and is statused (which is a copy-paste error from the Rain Dance handler). For Sunny weather, it should instead evaluate whether the opponent has Leaf Guard and is *not* statused (since Leaf Guard prevents status in Sun, but does not *heal* status conditions like Hydration).
@@ -1026,7 +1026,7 @@ Open the relevant file and change the byte at the provided offsets:
   <summary>You can also search for these bytes instead</summary>
   |               | Vanilla Bytes (Type 1)                                   | Vanilla Bytes (Type 2)                                   |
   |:-------------:|:--------------------------------------------------------:|:--------------------------------------------------------:|
-  | **All Games** | `4D 00 00 00 1E 00 00 00 01 00 00 00 13 00 00 00`        | `0E 00 00 00 1E 00 00 00 03 00 00 00 13 00 00 00`        |
+  | **All Games** | `01 00 00 00 13 00 00 00 07 00 00 00 0E 00 00 00`        | `03 00 00 00 13 00 00 00 07 00 00 00 09 00 00 00`        |
 </details>
 
 When considering whether to use Foresight or Odor Sleuth to enable Normal/Fighting moves to hit Ghost-type targets, the Expert Trainer AI evaluates the *user's* typing instead of the *target's* typing. This means the AI will only attempt to use these moves if its own Pokémon is a Ghost-type, rather than when the opponent is a Ghost-type.
@@ -1052,7 +1052,7 @@ Open the relevant file and change the byte at the provided offset:
   <summary>You can also search for these bytes instead</summary>
   |               | Vanilla Bytes                                            |
   |:-------------:|:--------------------------------------------------------:|
-  | **All Games** | `4D 00 00 00 0A 00 00 00 00 00 00 00 D8 00 00 00`        |
+  | **All Games** | `00 00 00 00 D8 00 00 00`        |
 </details>
 
 When evaluating the move Facade, the Expert Trainer AI checks if the target has a status condition (poison, burn, paralysis), rather than checking if the user itself is statused (which would boost the move's power). As a result, the AI incorrectly rewards using Facade when the *opponent* is statused instead of when the AI's own Pokémon is statused.
@@ -1076,7 +1076,7 @@ Open the relevant file and change the byte at the provided offset:
   <summary>You can also search for these bytes instead</summary>
   |               | Vanilla Bytes                                            |
   |:-------------:|:--------------------------------------------------------:|
-  | **All Games** | `66 00 00 00 0C 00 00 00 09 00 00 00 01 00 00 00`        |
+  | **All Games** | `09 00 00 00 01 00 00 00 FF 00 00 00 02 00 00 00 4C 00 00 00 06 00 00 00 04 00 00 00 01 00 00 00 4C 00 00 00 02 00 00 00 04 00 00 00 FF FF FF FF 4D 00 00 00 05 00 00 00 01 00 00 00 5A 00 00 00`        |
 </details>
 
 Under Sunny weather, the Leaf Guard ability protects a Pokémon from receiving status conditions, but does not *heal* status conditions like Hydration. When scoring the move Sunny Day, the Expert Trainer AI evaluates whether its Pokémon has Leaf Guard and checks if it is *already* statused. However, the logic is inverted: it checks `IfStatus` (0x09) and awards a score bonus only if the Pokémon is already statused, rather than when it is healthy.
@@ -1100,7 +1100,7 @@ Open the relevant file and change the byte at the provided offsets:
   <summary>You can also search for these bytes instead</summary>
   |               | Vanilla Bytes (Faster)                                   | Vanilla Bytes (Slower)                                   |
   |:-------------:|:--------------------------------------------------------:|:--------------------------------------------------------:|
-  | **All Games** | `06 00 00 00 06 00 00 00 00 00 00 00 32 00 00 00`        | `04 00 00 00 06 00 00 00 00 00 00 00 46 00 00 00`        |
+  | **All Games** | `00 00 00 00 32 00 00 00 08 00 00 00 4C 00 00 00`        | `00 00 00 00 46 00 00 00 02 00 00 00 04 00 00 00 FF FF FF FF`        |
 </details>
 
 When considering whether to use Water Spout or Eruption, the Expert Trainer AI evaluates the target's HP percentage rather than its own. Since these moves deal damage proportional to the user's remaining HP, the AI will incorrectly avoid using these moves when its own Pokémon is at full HP if the target is low on health, or utilize them poorly when its own Pokémon is near fainting if the target is healthy.
@@ -1124,7 +1124,7 @@ Open the relevant file and change the bytes at the provided offset:
   <summary>You can also search for these bytes instead</summary>
   |               | Vanilla Bytes                                            |
   |:-------------:|:--------------------------------------------------------:|
-  | **All Games** | `4D 00 00 00 04 00 00 00 01 00 00 00 4D 00 00 00`        |
+  | **All Games** | `01 00 00 00 4D 00 00 00 04 00 00 00 05 00 00 00`        |
 </details>
 
 When evaluating charge-turn semi-invulnerable moves (such as Fly or Dig), the Expert Trainer AI includes logic that triggers if the opponent is immune or resistant to the move. However, instead of penalizing this move, a bug in the scoring block adds `+1` to the move score. This causes the AI to erroneously favor using Ground-type Dig against immune Flying-type opponents, or using Flying-type Fly against Electric-types.

--- a/package-lock.json
+++ b/package-lock.json
@@ -168,6 +168,7 @@
       "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-5.52.1.tgz",
       "integrity": "sha512-gA8oJOV1LnQQkDf91iebNnFInHuW0gRPEgLSOQ7EfipCEjYTHm5swm1DlH9H5RaRw4RrHuzHBegnlzc0MAstcg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@algolia/client-common": "5.52.1",
         "@algolia/requester-browser-xhr": "5.52.1",
@@ -306,6 +307,7 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -2119,6 +2121,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -2141,6 +2144,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2250,6 +2254,7 @@
       "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.1.tgz",
       "integrity": "sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"
@@ -2671,6 +2676,7 @@
       "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.1.tgz",
       "integrity": "sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"
@@ -3699,6 +3705,7 @@
       "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-docs/-/plugin-content-docs-3.10.1.tgz",
       "integrity": "sha512-2jRVrtzjf8LClGTHQlwlwuD3wQXRx3WEoF7XUarJ8Ou+0onV+SLtejsyfY9JLpfUh9hPhXM4pbBGkyAY4Bi3HQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@docusaurus/core": "3.10.1",
         "@docusaurus/logger": "3.10.1",
@@ -3968,6 +3975,7 @@
       "resolved": "https://registry.npmjs.org/@docusaurus/theme-common/-/theme-common-3.10.1.tgz",
       "integrity": "sha512-0YtmIeoNo1fIw65LO8+/1dPgmDV86UmhMkow37gzjytuiCSQm9xob6PJy0L4kuQEMTLfUOGvkXvZr7GPrHquMA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@docusaurus/mdx-loader": "3.10.1",
         "@docusaurus/module-type-aliases": "3.10.1",
@@ -4847,6 +4855,7 @@
     "node_modules/@mdx-js/react": {
       "version": "3.0.1",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/mdx": "^2.0.0"
       },
@@ -5546,6 +5555,7 @@
       "resolved": "https://registry.npmjs.org/@svgr/core/-/core-8.1.0.tgz",
       "integrity": "sha512-8QqtOQT5ACVlmsvKOJNEaWmRPmcojMOzCz4Hs2BGG/toAp/K38LcsMRyLp349glq5AzJbCEeimEoxaX6v/fLrA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/core": "^7.21.3",
         "@svgr/babel-preset": "8.1.0",
@@ -6090,6 +6100,7 @@
     "node_modules/@types/react": {
       "version": "18.3.10",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.0.2"
@@ -6437,6 +6448,7 @@
     "node_modules/acorn": {
       "version": "8.15.0",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -6496,6 +6508,7 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
       "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -6541,6 +6554,7 @@
       "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-5.52.1.tgz",
       "integrity": "sha512-fHA8+kXTbjagw3jkLiaS7KKrH8qe2DyOsiUhGlN4cdT77PEsfqXZl7ewDk1hsg+pJnPlnE50XtLxjR91iJOpmg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@algolia/abtesting": "1.18.1",
         "@algolia/client-abtesting": "5.52.1",
@@ -6984,6 +6998,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -7888,6 +7903,7 @@
       "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.1.tgz",
       "integrity": "sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"
@@ -8199,6 +8215,7 @@
       "resolved": "https://registry.npmjs.org/cytoscape/-/cytoscape-3.33.3.tgz",
       "integrity": "sha512-Gej7U+OKR+LZ8kvX7rb2HhCYJ0IhvEFsnkud4SB1PR+BUY/TsSO0dmOW59WEVLu51b1Rm+gQRKoz4bLYxGSZ2g==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10"
       }
@@ -8590,6 +8607,7 @@
       "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
       "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -9610,6 +9628,7 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
       "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -13989,6 +14008,7 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
       "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -14537,6 +14557,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -15440,6 +15461,7 @@
       "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.1.tgz",
       "integrity": "sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"
@@ -16227,6 +16249,7 @@
     "node_modules/react": {
       "version": "18.3.1",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -16237,6 +16260,7 @@
     "node_modules/react-dom": {
       "version": "18.3.1",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -16284,6 +16308,7 @@
       "name": "@docusaurus/react-loadable",
       "version": "6.0.0",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/react": "*"
       },
@@ -16310,6 +16335,7 @@
     "node_modules/react-router": {
       "version": "5.3.4",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.12.13",
         "history": "^4.9.0",
@@ -17955,7 +17981,8 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "license": "0BSD"
+      "license": "0BSD",
+      "peer": true
     },
     "node_modules/tsyringe": {
       "version": "4.10.0",
@@ -18030,6 +18057,7 @@
       "version": "5.2.2",
       "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -18385,6 +18413,7 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
       "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -18563,6 +18592,7 @@
       "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.105.2.tgz",
       "integrity": "sha512-dRXm0a2qcHPUBEzVk8uph0xWSjV/xZxenQQbLwnwP7caQCYpqG1qddwlyEkIDkYn0K8tvmcrZ+bOrzoQ3HxCDw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.7",
         "@types/estree": "^1.0.8",
@@ -19201,6 +19231,7 @@
       "version": "5.52.1",
       "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-5.52.1.tgz",
       "integrity": "sha512-gA8oJOV1LnQQkDf91iebNnFInHuW0gRPEgLSOQ7EfipCEjYTHm5swm1DlH9H5RaRw4RrHuzHBegnlzc0MAstcg==",
+      "peer": true,
       "requires": {
         "@algolia/client-common": "5.52.1",
         "@algolia/requester-browser-xhr": "5.52.1",
@@ -19298,6 +19329,7 @@
       "version": "7.29.0",
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
+      "peer": true,
       "requires": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -20369,12 +20401,14 @@
       "version": "3.0.5",
       "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz",
       "integrity": "sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==",
+      "peer": true,
       "requires": {}
     },
     "@csstools/css-tokenizer": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.4.tgz",
-      "integrity": "sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw=="
+      "integrity": "sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==",
+      "peer": true
     },
     "@csstools/media-query-list-parser": {
       "version": "4.0.3",
@@ -20413,6 +20447,7 @@
           "version": "7.1.1",
           "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.1.tgz",
           "integrity": "sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==",
+          "peer": true,
           "requires": {
             "cssesc": "^3.0.0",
             "util-deprecate": "^1.0.2"
@@ -20579,6 +20614,7 @@
           "version": "7.1.1",
           "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.1.tgz",
           "integrity": "sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==",
+          "peer": true,
           "requires": {
             "cssesc": "^3.0.0",
             "util-deprecate": "^1.0.2"
@@ -21069,6 +21105,7 @@
       "version": "3.10.1",
       "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-docs/-/plugin-content-docs-3.10.1.tgz",
       "integrity": "sha512-2jRVrtzjf8LClGTHQlwlwuD3wQXRx3WEoF7XUarJ8Ou+0onV+SLtejsyfY9JLpfUh9hPhXM4pbBGkyAY4Bi3HQ==",
+      "peer": true,
       "requires": {
         "@docusaurus/core": "3.10.1",
         "@docusaurus/logger": "3.10.1",
@@ -21254,6 +21291,7 @@
       "version": "3.10.1",
       "resolved": "https://registry.npmjs.org/@docusaurus/theme-common/-/theme-common-3.10.1.tgz",
       "integrity": "sha512-0YtmIeoNo1fIw65LO8+/1dPgmDV86UmhMkow37gzjytuiCSQm9xob6PJy0L4kuQEMTLfUOGvkXvZr7GPrHquMA==",
+      "peer": true,
       "requires": {
         "@docusaurus/mdx-loader": "3.10.1",
         "@docusaurus/module-type-aliases": "3.10.1",
@@ -21808,6 +21846,7 @@
     },
     "@mdx-js/react": {
       "version": "3.0.1",
+      "peer": true,
       "requires": {
         "@types/mdx": "^2.0.0"
       }
@@ -22219,6 +22258,7 @@
       "version": "8.1.0",
       "resolved": "https://registry.npmjs.org/@svgr/core/-/core-8.1.0.tgz",
       "integrity": "sha512-8QqtOQT5ACVlmsvKOJNEaWmRPmcojMOzCz4Hs2BGG/toAp/K38LcsMRyLp349glq5AzJbCEeimEoxaX6v/fLrA==",
+      "peer": true,
       "requires": {
         "@babel/core": "^7.21.3",
         "@svgr/babel-preset": "8.1.0",
@@ -22648,6 +22688,7 @@
     },
     "@types/react": {
       "version": "18.3.10",
+      "peer": true,
       "requires": {
         "@types/prop-types": "*",
         "csstype": "^3.0.2"
@@ -22947,7 +22988,8 @@
       }
     },
     "acorn": {
-      "version": "8.15.0"
+      "version": "8.15.0",
+      "peer": true
     },
     "acorn-import-phases": {
       "version": "1.0.4",
@@ -22979,6 +23021,7 @@
       "version": "8.18.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
       "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+      "peer": true,
       "requires": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -23006,6 +23049,7 @@
       "version": "5.52.1",
       "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-5.52.1.tgz",
       "integrity": "sha512-fHA8+kXTbjagw3jkLiaS7KKrH8qe2DyOsiUhGlN4cdT77PEsfqXZl7ewDk1hsg+pJnPlnE50XtLxjR91iJOpmg==",
+      "peer": true,
       "requires": {
         "@algolia/abtesting": "1.18.1",
         "@algolia/client-abtesting": "5.52.1",
@@ -23283,6 +23327,7 @@
       "version": "4.28.2",
       "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz",
       "integrity": "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==",
+      "peer": true,
       "requires": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -23798,6 +23843,7 @@
           "version": "7.1.1",
           "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.1.tgz",
           "integrity": "sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==",
+          "peer": true,
           "requires": {
             "cssesc": "^3.0.0",
             "util-deprecate": "^1.0.2"
@@ -23965,7 +24011,8 @@
     "cytoscape": {
       "version": "3.33.3",
       "resolved": "https://registry.npmjs.org/cytoscape/-/cytoscape-3.33.3.tgz",
-      "integrity": "sha512-Gej7U+OKR+LZ8kvX7rb2HhCYJ0IhvEFsnkud4SB1PR+BUY/TsSO0dmOW59WEVLu51b1Rm+gQRKoz4bLYxGSZ2g=="
+      "integrity": "sha512-Gej7U+OKR+LZ8kvX7rb2HhCYJ0IhvEFsnkud4SB1PR+BUY/TsSO0dmOW59WEVLu51b1Rm+gQRKoz4bLYxGSZ2g==",
+      "peer": true
     },
     "cytoscape-cose-bilkent": {
       "version": "4.1.0",
@@ -24232,7 +24279,8 @@
     "d3-selection": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
-      "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ=="
+      "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
+      "peer": true
     },
     "d3-shape": {
       "version": "3.2.0",
@@ -24858,6 +24906,7 @@
           "version": "6.14.0",
           "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
           "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
+          "peer": true,
           "requires": {
             "fast-deep-equal": "^3.1.1",
             "fast-json-stable-stringify": "^2.0.0",
@@ -27284,6 +27333,7 @@
           "version": "6.15.0",
           "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
           "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
+          "peer": true,
           "requires": {
             "fast-deep-equal": "^3.1.1",
             "fast-json-stable-stringify": "^2.0.0",
@@ -27623,6 +27673,7 @@
       "version": "8.5.14",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.14.tgz",
       "integrity": "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==",
+      "peer": true,
       "requires": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -28055,6 +28106,7 @@
           "version": "7.1.1",
           "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.1.tgz",
           "integrity": "sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==",
+          "peer": true,
           "requires": {
             "cssesc": "^3.0.0",
             "util-deprecate": "^1.0.2"
@@ -28514,12 +28566,14 @@
     },
     "react": {
       "version": "18.3.1",
+      "peer": true,
       "requires": {
         "loose-envify": "^1.1.0"
       }
     },
     "react-dom": {
       "version": "18.3.1",
+      "peer": true,
       "requires": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -28549,6 +28603,7 @@
     },
     "react-loadable": {
       "version": "npm:@docusaurus/react-loadable@6.0.0",
+      "peer": true,
       "requires": {
         "@types/react": "*"
       }
@@ -28563,6 +28618,7 @@
     },
     "react-router": {
       "version": "5.3.4",
+      "peer": true,
       "requires": {
         "@babel/runtime": "^7.12.13",
         "history": "^4.9.0",
@@ -29581,7 +29637,8 @@
     "tslib": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "peer": true
     },
     "tsyringe": {
       "version": "4.10.0",
@@ -29633,7 +29690,8 @@
     },
     "typescript": {
       "version": "5.2.2",
-      "devOptional": true
+      "devOptional": true,
+      "peer": true
     },
     "ufo": {
       "version": "1.6.3",
@@ -29828,6 +29886,7 @@
           "version": "6.14.0",
           "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
           "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
+          "peer": true,
           "requires": {
             "fast-deep-equal": "^3.1.1",
             "fast-json-stable-stringify": "^2.0.0",
@@ -29935,6 +29994,7 @@
       "version": "5.105.2",
       "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.105.2.tgz",
       "integrity": "sha512-dRXm0a2qcHPUBEzVk8uph0xWSjV/xZxenQQbLwnwP7caQCYpqG1qddwlyEkIDkYn0K8tvmcrZ+bOrzoQ3HxCDw==",
+      "peer": true,
       "requires": {
         "@types/eslint-scope": "^3.7.7",
         "@types/estree": "^1.0.8",

--- a/package-lock.json
+++ b/package-lock.json
@@ -168,7 +168,6 @@
       "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-5.52.1.tgz",
       "integrity": "sha512-gA8oJOV1LnQQkDf91iebNnFInHuW0gRPEgLSOQ7EfipCEjYTHm5swm1DlH9H5RaRw4RrHuzHBegnlzc0MAstcg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@algolia/client-common": "5.52.1",
         "@algolia/requester-browser-xhr": "5.52.1",
@@ -307,7 +306,6 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -2121,7 +2119,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -2144,7 +2141,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2254,7 +2250,6 @@
       "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.1.tgz",
       "integrity": "sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"
@@ -2676,7 +2671,6 @@
       "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.1.tgz",
       "integrity": "sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"
@@ -3705,7 +3699,6 @@
       "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-docs/-/plugin-content-docs-3.10.1.tgz",
       "integrity": "sha512-2jRVrtzjf8LClGTHQlwlwuD3wQXRx3WEoF7XUarJ8Ou+0onV+SLtejsyfY9JLpfUh9hPhXM4pbBGkyAY4Bi3HQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@docusaurus/core": "3.10.1",
         "@docusaurus/logger": "3.10.1",
@@ -3975,7 +3968,6 @@
       "resolved": "https://registry.npmjs.org/@docusaurus/theme-common/-/theme-common-3.10.1.tgz",
       "integrity": "sha512-0YtmIeoNo1fIw65LO8+/1dPgmDV86UmhMkow37gzjytuiCSQm9xob6PJy0L4kuQEMTLfUOGvkXvZr7GPrHquMA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@docusaurus/mdx-loader": "3.10.1",
         "@docusaurus/module-type-aliases": "3.10.1",
@@ -4855,7 +4847,6 @@
     "node_modules/@mdx-js/react": {
       "version": "3.0.1",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/mdx": "^2.0.0"
       },
@@ -5555,7 +5546,6 @@
       "resolved": "https://registry.npmjs.org/@svgr/core/-/core-8.1.0.tgz",
       "integrity": "sha512-8QqtOQT5ACVlmsvKOJNEaWmRPmcojMOzCz4Hs2BGG/toAp/K38LcsMRyLp349glq5AzJbCEeimEoxaX6v/fLrA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/core": "^7.21.3",
         "@svgr/babel-preset": "8.1.0",
@@ -6100,7 +6090,6 @@
     "node_modules/@types/react": {
       "version": "18.3.10",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.0.2"
@@ -6448,7 +6437,6 @@
     "node_modules/acorn": {
       "version": "8.15.0",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -6508,7 +6496,6 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
       "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -6554,7 +6541,6 @@
       "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-5.52.1.tgz",
       "integrity": "sha512-fHA8+kXTbjagw3jkLiaS7KKrH8qe2DyOsiUhGlN4cdT77PEsfqXZl7ewDk1hsg+pJnPlnE50XtLxjR91iJOpmg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@algolia/abtesting": "1.18.1",
         "@algolia/client-abtesting": "5.52.1",
@@ -6998,7 +6984,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -7903,7 +7888,6 @@
       "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.1.tgz",
       "integrity": "sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"
@@ -8215,7 +8199,6 @@
       "resolved": "https://registry.npmjs.org/cytoscape/-/cytoscape-3.33.3.tgz",
       "integrity": "sha512-Gej7U+OKR+LZ8kvX7rb2HhCYJ0IhvEFsnkud4SB1PR+BUY/TsSO0dmOW59WEVLu51b1Rm+gQRKoz4bLYxGSZ2g==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10"
       }
@@ -8607,7 +8590,6 @@
       "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
       "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
       "license": "ISC",
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -9628,7 +9610,6 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
       "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -14008,7 +13989,6 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
       "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -14557,7 +14537,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -15461,7 +15440,6 @@
       "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.1.tgz",
       "integrity": "sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"
@@ -16249,7 +16227,6 @@
     "node_modules/react": {
       "version": "18.3.1",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -16260,7 +16237,6 @@
     "node_modules/react-dom": {
       "version": "18.3.1",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -16308,7 +16284,6 @@
       "name": "@docusaurus/react-loadable",
       "version": "6.0.0",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/react": "*"
       },
@@ -16335,7 +16310,6 @@
     "node_modules/react-router": {
       "version": "5.3.4",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.12.13",
         "history": "^4.9.0",
@@ -17981,8 +17955,7 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "license": "0BSD",
-      "peer": true
+      "license": "0BSD"
     },
     "node_modules/tsyringe": {
       "version": "4.10.0",
@@ -18057,7 +18030,6 @@
       "version": "5.2.2",
       "devOptional": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -18413,7 +18385,6 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
       "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -18592,7 +18563,6 @@
       "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.105.2.tgz",
       "integrity": "sha512-dRXm0a2qcHPUBEzVk8uph0xWSjV/xZxenQQbLwnwP7caQCYpqG1qddwlyEkIDkYn0K8tvmcrZ+bOrzoQ3HxCDw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.7",
         "@types/estree": "^1.0.8",
@@ -19231,7 +19201,6 @@
       "version": "5.52.1",
       "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-5.52.1.tgz",
       "integrity": "sha512-gA8oJOV1LnQQkDf91iebNnFInHuW0gRPEgLSOQ7EfipCEjYTHm5swm1DlH9H5RaRw4RrHuzHBegnlzc0MAstcg==",
-      "peer": true,
       "requires": {
         "@algolia/client-common": "5.52.1",
         "@algolia/requester-browser-xhr": "5.52.1",
@@ -19329,7 +19298,6 @@
       "version": "7.29.0",
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
-      "peer": true,
       "requires": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -20401,14 +20369,12 @@
       "version": "3.0.5",
       "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz",
       "integrity": "sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==",
-      "peer": true,
       "requires": {}
     },
     "@csstools/css-tokenizer": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.4.tgz",
-      "integrity": "sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==",
-      "peer": true
+      "integrity": "sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw=="
     },
     "@csstools/media-query-list-parser": {
       "version": "4.0.3",
@@ -20447,7 +20413,6 @@
           "version": "7.1.1",
           "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.1.tgz",
           "integrity": "sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==",
-          "peer": true,
           "requires": {
             "cssesc": "^3.0.0",
             "util-deprecate": "^1.0.2"
@@ -20614,7 +20579,6 @@
           "version": "7.1.1",
           "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.1.tgz",
           "integrity": "sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==",
-          "peer": true,
           "requires": {
             "cssesc": "^3.0.0",
             "util-deprecate": "^1.0.2"
@@ -21105,7 +21069,6 @@
       "version": "3.10.1",
       "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-docs/-/plugin-content-docs-3.10.1.tgz",
       "integrity": "sha512-2jRVrtzjf8LClGTHQlwlwuD3wQXRx3WEoF7XUarJ8Ou+0onV+SLtejsyfY9JLpfUh9hPhXM4pbBGkyAY4Bi3HQ==",
-      "peer": true,
       "requires": {
         "@docusaurus/core": "3.10.1",
         "@docusaurus/logger": "3.10.1",
@@ -21291,7 +21254,6 @@
       "version": "3.10.1",
       "resolved": "https://registry.npmjs.org/@docusaurus/theme-common/-/theme-common-3.10.1.tgz",
       "integrity": "sha512-0YtmIeoNo1fIw65LO8+/1dPgmDV86UmhMkow37gzjytuiCSQm9xob6PJy0L4kuQEMTLfUOGvkXvZr7GPrHquMA==",
-      "peer": true,
       "requires": {
         "@docusaurus/mdx-loader": "3.10.1",
         "@docusaurus/module-type-aliases": "3.10.1",
@@ -21846,7 +21808,6 @@
     },
     "@mdx-js/react": {
       "version": "3.0.1",
-      "peer": true,
       "requires": {
         "@types/mdx": "^2.0.0"
       }
@@ -22258,7 +22219,6 @@
       "version": "8.1.0",
       "resolved": "https://registry.npmjs.org/@svgr/core/-/core-8.1.0.tgz",
       "integrity": "sha512-8QqtOQT5ACVlmsvKOJNEaWmRPmcojMOzCz4Hs2BGG/toAp/K38LcsMRyLp349glq5AzJbCEeimEoxaX6v/fLrA==",
-      "peer": true,
       "requires": {
         "@babel/core": "^7.21.3",
         "@svgr/babel-preset": "8.1.0",
@@ -22688,7 +22648,6 @@
     },
     "@types/react": {
       "version": "18.3.10",
-      "peer": true,
       "requires": {
         "@types/prop-types": "*",
         "csstype": "^3.0.2"
@@ -22988,8 +22947,7 @@
       }
     },
     "acorn": {
-      "version": "8.15.0",
-      "peer": true
+      "version": "8.15.0"
     },
     "acorn-import-phases": {
       "version": "1.0.4",
@@ -23021,7 +22979,6 @@
       "version": "8.18.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
       "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
-      "peer": true,
       "requires": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -23049,7 +23006,6 @@
       "version": "5.52.1",
       "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-5.52.1.tgz",
       "integrity": "sha512-fHA8+kXTbjagw3jkLiaS7KKrH8qe2DyOsiUhGlN4cdT77PEsfqXZl7ewDk1hsg+pJnPlnE50XtLxjR91iJOpmg==",
-      "peer": true,
       "requires": {
         "@algolia/abtesting": "1.18.1",
         "@algolia/client-abtesting": "5.52.1",
@@ -23327,7 +23283,6 @@
       "version": "4.28.2",
       "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz",
       "integrity": "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==",
-      "peer": true,
       "requires": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -23843,7 +23798,6 @@
           "version": "7.1.1",
           "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.1.tgz",
           "integrity": "sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==",
-          "peer": true,
           "requires": {
             "cssesc": "^3.0.0",
             "util-deprecate": "^1.0.2"
@@ -24011,8 +23965,7 @@
     "cytoscape": {
       "version": "3.33.3",
       "resolved": "https://registry.npmjs.org/cytoscape/-/cytoscape-3.33.3.tgz",
-      "integrity": "sha512-Gej7U+OKR+LZ8kvX7rb2HhCYJ0IhvEFsnkud4SB1PR+BUY/TsSO0dmOW59WEVLu51b1Rm+gQRKoz4bLYxGSZ2g==",
-      "peer": true
+      "integrity": "sha512-Gej7U+OKR+LZ8kvX7rb2HhCYJ0IhvEFsnkud4SB1PR+BUY/TsSO0dmOW59WEVLu51b1Rm+gQRKoz4bLYxGSZ2g=="
     },
     "cytoscape-cose-bilkent": {
       "version": "4.1.0",
@@ -24279,8 +24232,7 @@
     "d3-selection": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
-      "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
-      "peer": true
+      "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ=="
     },
     "d3-shape": {
       "version": "3.2.0",
@@ -24906,7 +24858,6 @@
           "version": "6.14.0",
           "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
           "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
-          "peer": true,
           "requires": {
             "fast-deep-equal": "^3.1.1",
             "fast-json-stable-stringify": "^2.0.0",
@@ -27333,7 +27284,6 @@
           "version": "6.15.0",
           "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
           "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
-          "peer": true,
           "requires": {
             "fast-deep-equal": "^3.1.1",
             "fast-json-stable-stringify": "^2.0.0",
@@ -27673,7 +27623,6 @@
       "version": "8.5.14",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.14.tgz",
       "integrity": "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==",
-      "peer": true,
       "requires": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -28106,7 +28055,6 @@
           "version": "7.1.1",
           "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.1.tgz",
           "integrity": "sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==",
-          "peer": true,
           "requires": {
             "cssesc": "^3.0.0",
             "util-deprecate": "^1.0.2"
@@ -28566,14 +28514,12 @@
     },
     "react": {
       "version": "18.3.1",
-      "peer": true,
       "requires": {
         "loose-envify": "^1.1.0"
       }
     },
     "react-dom": {
       "version": "18.3.1",
-      "peer": true,
       "requires": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -28603,7 +28549,6 @@
     },
     "react-loadable": {
       "version": "npm:@docusaurus/react-loadable@6.0.0",
-      "peer": true,
       "requires": {
         "@types/react": "*"
       }
@@ -28618,7 +28563,6 @@
     },
     "react-router": {
       "version": "5.3.4",
-      "peer": true,
       "requires": {
         "@babel/runtime": "^7.12.13",
         "history": "^4.9.0",
@@ -29637,8 +29581,7 @@
     "tslib": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "peer": true
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
     },
     "tsyringe": {
       "version": "4.10.0",
@@ -29690,8 +29633,7 @@
     },
     "typescript": {
       "version": "5.2.2",
-      "devOptional": true,
-      "peer": true
+      "devOptional": true
     },
     "ufo": {
       "version": "1.6.3",
@@ -29886,7 +29828,6 @@
           "version": "6.14.0",
           "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
           "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
-          "peer": true,
           "requires": {
             "fast-deep-equal": "^3.1.1",
             "fast-json-stable-stringify": "^2.0.0",
@@ -29994,7 +29935,6 @@
       "version": "5.105.2",
       "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.105.2.tgz",
       "integrity": "sha512-dRXm0a2qcHPUBEzVk8uph0xWSjV/xZxenQQbLwnwP7caQCYpqG1qddwlyEkIDkYn0K8tvmcrZ+bOrzoQ3HxCDw==",
-      "peer": true,
       "requires": {
         "@types/eslint-scope": "^3.7.7",
         "@types/estree": "^1.0.8",


### PR DESCRIPTION
Added a number of AI fixes to the battle edits page. These are the "simple" constant swap fixes, so it's not an exhaustive list, but the simple ones are included.
I've fully tested these on HG, and only identified the plat and diamond ones by byte pattern matching (but they are all unique matches).

- Trainer AI Basic Flag Sunny Day Check
- Trainer AI Expert Flag Foresight and Odor Sleuth Ghost Type Check
- Trainer AI Expert Flag Facade Status Check
- Trainer AI Expert Flag Leaf Guard Sunny Day Logic
- Trainer AI Expert Flag Water Spout and Eruption HP Check
- Trainer AI Expert Flag Charge-Turn Move Scoring Fix

Additional bonus of a method of allowing "Trick" to succeed when used by normal trainers:
- Bypass Trick 'Always Fail' Logic
