### PR TITLE
Added rock smash item and enc tables and mapping guide

### DIFF
--- a/docs/generation-iv/guides/hgss-rock_smash/hgss-rock_smash.md
+++ b/docs/generation-iv/guides/hgss-rock_smash/hgss-rock_smash.md
@@ -1,0 +1,122 @@
+---
+title: Rock Smash
+tags:
+  - Guide (HeartGold)
+  - Guide (SoulSilver)
+---
+
+# Rock Smash
+> Author(s): [MrHam88](https://github.com/DevHam88).  
+> Research: [pokeheartgold](https://github.com/pret/pokeheartgold/blob/master/src/field/overlay_01_rock_smash_item.c).
+
+This page is a guide to **Rock Smash** encounters and item drop in Pokémon HeartGold and SoulSilver. It covers how the game determines wild encounters, how item drops are calculated, the structure of the map-specific data archive, and the locations of the hardcoded item tables in the ROM's overlay.
+
+:::info
+In HGSS, Rock Smash interactions trigger a two-step check:
+1. **Wild Pokémon Encounter**: Checked first using the map's overworld encounter tables, defined in NARC `/a/0/3/7`.
+2. **Item Drop**: Rolled only if the wild encounter check fails. The drop rate and item table selection are map-dependent, defined in NARC `/a/2/5/3`.
+2. **Item Tables**: The contents of each item table are defined in Overlay 1.
+:::
+
+---
+
+## Glossary
+
+- **NARC `/a/2/5/3` (NARC Index 255)**: The map metadata archive for Rock Smash containing drop rates and table configurations.
+- **Encounter Rate**: The base probability of triggering a wild encounter when smashing a rock.
+- **Drop Odds**: The base probability (out of 100) of revealing an item when smashing a rock.
+- **Table Type**: An identifier that maps a location to one of three hardcoded lists of item rewards.
+
+---
+
+## Wild Pokémon Encounters
+
+Before rolling for items, the game checks if a wild encounter occurs. This is handled by a generic encounter calculation.
+
+### How the game checks for encounters
+The game reads the `encounterRate_rockSmash` byte at offset `0x02` of the loaded encounter data table, and editable via DSPRE's Encounter Editor.
+* If this rate is `0`, a wild encounter is impossible, and the game proceeds immediately to the item drop check.
+* If it is non-zero, the encounter rate can be modified by the leading party Pokémon's ability:
+  * **2.0x multiplier**: `Arena Trap`, `No Guard`, or `Illuminate`.
+  * **0.5x multiplier**: `Stench`, `Quick Feet`, `White Smoke`, or `Snow Cloak` (only if weather is currently Hail).
+* The final adjusted rate is capped at 100%.
+* The game rolls `LCRandom() % 100`. If the roll is less than the final encounter rate, a battle begins against one of the two species defined in the map's `rockSmashSlots` (species and min/max levels defined from offset `0x78` in the encounter table, and editable via DSPRE's Encounter Editor.).
+
+**If a wild battle is triggered, no item drop check is performed.**
+
+---
+
+## Item Drop Rates
+
+If the wild encounter roll fails, the game rolls for an item drop using data from NARC `/a/2/5/3`.
+
+### NARC Structure and Identity
+- **File path**: `data/a/2/5/3`
+- **Indexing**: Each member file in this NARC corresponds directly to a **Map Header ID** (i.e. `member N = Map Header N`).
+- **File Layout**: Every member file is exactly **4 bytes** long, mapping to the following struct:
+
+| Offset | Field | Size | Description |
+|:---:|---|:---:|---|
+| `0x00` | `odds` | `uint16` (little-endian) | Base item drop chance (0 to 100). `0` disables item drops for this map. |
+| `0x02` | `type` | `uint16` (little-endian) | Drop table selector (0 = Default, 1 = Ruins of Alph, 2 = Cliff Cave). |
+
+### Base Odds Modifiers
+If the base odds are non-zero, they can be modified by:
+- **+5%** if the lead party Pokémon has the ability `Suction Cups`, `Magnet Pull`, or `Keen Eye`.
+- **+5%** if the player is followed by a Pokémon that executed the Rock Smash HM.
+The final drop rate is capped at 100%. If `LCRandom() % 100 < final_drop_rate`, an item is awarded.
+
+---
+
+## Item Selection Logic and Tables
+
+Once an item drop is confirmed, the game rolls a random slot index (0 to 7) based on the following probability distribution:
+
+| Slot | Base Probability |
+|:---:|:---:|
+| 0 | 25% |
+| 1 | 20% |
+| 2 | 10% |
+| 3 | 10% |
+| 4 | 10% |
+| 5 | 10% |
+| 6 | 10% |
+| 7 | 5% |
+
+### Ability Shift (Serene Grace / Super Luck)
+If the leading party Pokémon has the ability `Serene Grace` or `Super Luck`, and the rolled index is less than 7, the index is incremented by 1 (shifting the index to rarer slots, e.g. slot 0 is skipped and slot 7 becomes a 15% chance).
+
+---
+
+## Hardcoded Item Tables in ROM (Hex Editing)
+
+The three drop tables are hardcoded as static array constants within **Overlay 1** (`field`). In the ROM binary, this corresponds to `ov001.bin`.
+
+Because the game compiles with version-specific `#ifdef` blocks, the Ruins of Alph and Cliff Cave tables contain different species depending on whether you are editing HeartGold or SoulSilver.
+
+### Table Offsets in `ov001.bin`
+
+In HeartGold (decompressed `ov001.bin`), these three tables are compiled sequentially starting at offset **`0x23D04`** (RAM address `0x02209604`):
+
+### Vanilla Item Drop Tables
+
+Below is the layout of the 8 slots in the three hardcoded item tables, showing the values for both version compile types (HeartGold and SoulSilver):
+
+| Slot | Probability | Default Table (`type == 0`) <br /> Offset: `0x23D14` | Ruins of Alph Table (`type == 1`) <br /> Offset: `0x23D04` | Cliff Cave Table (`type == 2`) <br /> Offset: `0x23D24` |
+|:---:|:---:|---|---|---|
+| 0 | 25% | Max Ether | **HG**: Red Shard <br /> **SS**: Blue Shard | Max Ether |
+| 1 | 20% | Revive | **HG**: Yellow Shard <br /> **SS**: Green Shard | Pearl |
+| 2 | 10% | Heart Scale | **HG**: Helix Fossil <br /> **SS**: Dome Fossil | Big Pearl |
+| 3 | 10% | Red Shard | Max Ether | **HG**: Red Shard <br /> **SS**: Blue Shard |
+| 4 | 10% | Blue Shard | **HG**: Blue Shard <br /> **SS**: Red Shard | **HG**: Yellow Shard <br /> **SS**: Green Shard |
+| 5 | 10% | Green Shard | **HG**: Green Shard <br /> **SS**: Yellow Shard | **HG**: Claw Fossil <br /> **SS**: Root Fossil |
+| 6 | 10% | Yellow Shard | Old Amber | **HG**: Claw Fossil <br /> **SS**: Root Fossil |
+| 7 | 5% | Star Piece | Max Revive | Rare Bone |
+
+
+---
+
+## See Also
+
+- [Wiki: HGSS File Structure](../../resources/hgss-file_structure) - Technical reference for HGSS archives.
+- [pret/pokeheartgold - overlay_01_rock_smash_item.c](https://github.com/pret/pokeheartgold/blob/master/src/field/overlay_01_rock_smash_item.c) - Technical implementation details.

--- a/docs/generation-iv/resources/hgss-file_structure/hgss-file_structure.mdx
+++ b/docs/generation-iv/resources/hgss-file_structure/hgss-file_structure.mdx
@@ -43,7 +43,7 @@ import FilterableSortableTable from '/src/components/FilterableSortableTable';
 | Pokemon Data | Leftover Files | /a/2/2/8 | /poketool/pokegra/dp_poke_icon.narc | Leftover DP Pokemon Icons |
 | Encounter Data |  | /a/0/3/7 | | HG Field Encounters |
 | Encounter Data |  | /a/1/3/6 | | SS Field Encounters |
-| Encounter Data |  | /a/2/5/3 | | Unused/Dummy Headbutt Data |
+| Encounter Data |  | /a/2/5/3 | | Rock Smash Item Rates & Header to Item Table Map |
 | Encounter Data |  | /a/2/5/2 | | Headbutt Encounters (HG and SS) |
 | Encounter Data |  | /a/2/3/0 | sz_enc_data.narc | Safari Zone Encounters |
 | Encounter Data |  | /a/1/0/2 | encdata_ex.narc | Leftover D/P/Pt Encounters |

--- a/package-lock.json
+++ b/package-lock.json
@@ -168,6 +168,7 @@
       "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-5.52.1.tgz",
       "integrity": "sha512-gA8oJOV1LnQQkDf91iebNnFInHuW0gRPEgLSOQ7EfipCEjYTHm5swm1DlH9H5RaRw4RrHuzHBegnlzc0MAstcg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@algolia/client-common": "5.52.1",
         "@algolia/requester-browser-xhr": "5.52.1",
@@ -306,6 +307,7 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -2119,6 +2121,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -2141,6 +2144,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2250,6 +2254,7 @@
       "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.1.tgz",
       "integrity": "sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"
@@ -2671,6 +2676,7 @@
       "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.1.tgz",
       "integrity": "sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"
@@ -3699,6 +3705,7 @@
       "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-docs/-/plugin-content-docs-3.10.1.tgz",
       "integrity": "sha512-2jRVrtzjf8LClGTHQlwlwuD3wQXRx3WEoF7XUarJ8Ou+0onV+SLtejsyfY9JLpfUh9hPhXM4pbBGkyAY4Bi3HQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@docusaurus/core": "3.10.1",
         "@docusaurus/logger": "3.10.1",
@@ -3968,6 +3975,7 @@
       "resolved": "https://registry.npmjs.org/@docusaurus/theme-common/-/theme-common-3.10.1.tgz",
       "integrity": "sha512-0YtmIeoNo1fIw65LO8+/1dPgmDV86UmhMkow37gzjytuiCSQm9xob6PJy0L4kuQEMTLfUOGvkXvZr7GPrHquMA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@docusaurus/mdx-loader": "3.10.1",
         "@docusaurus/module-type-aliases": "3.10.1",
@@ -4847,6 +4855,7 @@
     "node_modules/@mdx-js/react": {
       "version": "3.0.1",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/mdx": "^2.0.0"
       },
@@ -5546,6 +5555,7 @@
       "resolved": "https://registry.npmjs.org/@svgr/core/-/core-8.1.0.tgz",
       "integrity": "sha512-8QqtOQT5ACVlmsvKOJNEaWmRPmcojMOzCz4Hs2BGG/toAp/K38LcsMRyLp349glq5AzJbCEeimEoxaX6v/fLrA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/core": "^7.21.3",
         "@svgr/babel-preset": "8.1.0",
@@ -6090,6 +6100,7 @@
     "node_modules/@types/react": {
       "version": "18.3.10",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.0.2"
@@ -6437,6 +6448,7 @@
     "node_modules/acorn": {
       "version": "8.15.0",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -6496,6 +6508,7 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
       "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -6541,6 +6554,7 @@
       "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-5.52.1.tgz",
       "integrity": "sha512-fHA8+kXTbjagw3jkLiaS7KKrH8qe2DyOsiUhGlN4cdT77PEsfqXZl7ewDk1hsg+pJnPlnE50XtLxjR91iJOpmg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@algolia/abtesting": "1.18.1",
         "@algolia/client-abtesting": "5.52.1",
@@ -6984,6 +6998,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -7888,6 +7903,7 @@
       "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.1.tgz",
       "integrity": "sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"
@@ -8199,6 +8215,7 @@
       "resolved": "https://registry.npmjs.org/cytoscape/-/cytoscape-3.33.3.tgz",
       "integrity": "sha512-Gej7U+OKR+LZ8kvX7rb2HhCYJ0IhvEFsnkud4SB1PR+BUY/TsSO0dmOW59WEVLu51b1Rm+gQRKoz4bLYxGSZ2g==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10"
       }
@@ -8590,6 +8607,7 @@
       "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
       "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -9610,6 +9628,7 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
       "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -13989,6 +14008,7 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
       "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -14537,6 +14557,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -15440,6 +15461,7 @@
       "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.1.tgz",
       "integrity": "sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"
@@ -16227,6 +16249,7 @@
     "node_modules/react": {
       "version": "18.3.1",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -16237,6 +16260,7 @@
     "node_modules/react-dom": {
       "version": "18.3.1",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -16284,6 +16308,7 @@
       "name": "@docusaurus/react-loadable",
       "version": "6.0.0",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/react": "*"
       },
@@ -16310,6 +16335,7 @@
     "node_modules/react-router": {
       "version": "5.3.4",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.12.13",
         "history": "^4.9.0",
@@ -17955,7 +17981,8 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "license": "0BSD"
+      "license": "0BSD",
+      "peer": true
     },
     "node_modules/tsyringe": {
       "version": "4.10.0",
@@ -18030,6 +18057,7 @@
       "version": "5.2.2",
       "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -18385,6 +18413,7 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
       "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -18563,6 +18592,7 @@
       "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.105.2.tgz",
       "integrity": "sha512-dRXm0a2qcHPUBEzVk8uph0xWSjV/xZxenQQbLwnwP7caQCYpqG1qddwlyEkIDkYn0K8tvmcrZ+bOrzoQ3HxCDw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.7",
         "@types/estree": "^1.0.8",
@@ -19201,6 +19231,7 @@
       "version": "5.52.1",
       "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-5.52.1.tgz",
       "integrity": "sha512-gA8oJOV1LnQQkDf91iebNnFInHuW0gRPEgLSOQ7EfipCEjYTHm5swm1DlH9H5RaRw4RrHuzHBegnlzc0MAstcg==",
+      "peer": true,
       "requires": {
         "@algolia/client-common": "5.52.1",
         "@algolia/requester-browser-xhr": "5.52.1",
@@ -19298,6 +19329,7 @@
       "version": "7.29.0",
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
+      "peer": true,
       "requires": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -20369,12 +20401,14 @@
       "version": "3.0.5",
       "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz",
       "integrity": "sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==",
+      "peer": true,
       "requires": {}
     },
     "@csstools/css-tokenizer": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.4.tgz",
-      "integrity": "sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw=="
+      "integrity": "sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==",
+      "peer": true
     },
     "@csstools/media-query-list-parser": {
       "version": "4.0.3",
@@ -20413,6 +20447,7 @@
           "version": "7.1.1",
           "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.1.tgz",
           "integrity": "sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==",
+          "peer": true,
           "requires": {
             "cssesc": "^3.0.0",
             "util-deprecate": "^1.0.2"
@@ -20579,6 +20614,7 @@
           "version": "7.1.1",
           "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.1.tgz",
           "integrity": "sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==",
+          "peer": true,
           "requires": {
             "cssesc": "^3.0.0",
             "util-deprecate": "^1.0.2"
@@ -21069,6 +21105,7 @@
       "version": "3.10.1",
       "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-docs/-/plugin-content-docs-3.10.1.tgz",
       "integrity": "sha512-2jRVrtzjf8LClGTHQlwlwuD3wQXRx3WEoF7XUarJ8Ou+0onV+SLtejsyfY9JLpfUh9hPhXM4pbBGkyAY4Bi3HQ==",
+      "peer": true,
       "requires": {
         "@docusaurus/core": "3.10.1",
         "@docusaurus/logger": "3.10.1",
@@ -21254,6 +21291,7 @@
       "version": "3.10.1",
       "resolved": "https://registry.npmjs.org/@docusaurus/theme-common/-/theme-common-3.10.1.tgz",
       "integrity": "sha512-0YtmIeoNo1fIw65LO8+/1dPgmDV86UmhMkow37gzjytuiCSQm9xob6PJy0L4kuQEMTLfUOGvkXvZr7GPrHquMA==",
+      "peer": true,
       "requires": {
         "@docusaurus/mdx-loader": "3.10.1",
         "@docusaurus/module-type-aliases": "3.10.1",
@@ -21808,6 +21846,7 @@
     },
     "@mdx-js/react": {
       "version": "3.0.1",
+      "peer": true,
       "requires": {
         "@types/mdx": "^2.0.0"
       }
@@ -22219,6 +22258,7 @@
       "version": "8.1.0",
       "resolved": "https://registry.npmjs.org/@svgr/core/-/core-8.1.0.tgz",
       "integrity": "sha512-8QqtOQT5ACVlmsvKOJNEaWmRPmcojMOzCz4Hs2BGG/toAp/K38LcsMRyLp349glq5AzJbCEeimEoxaX6v/fLrA==",
+      "peer": true,
       "requires": {
         "@babel/core": "^7.21.3",
         "@svgr/babel-preset": "8.1.0",
@@ -22648,6 +22688,7 @@
     },
     "@types/react": {
       "version": "18.3.10",
+      "peer": true,
       "requires": {
         "@types/prop-types": "*",
         "csstype": "^3.0.2"
@@ -22947,7 +22988,8 @@
       }
     },
     "acorn": {
-      "version": "8.15.0"
+      "version": "8.15.0",
+      "peer": true
     },
     "acorn-import-phases": {
       "version": "1.0.4",
@@ -22979,6 +23021,7 @@
       "version": "8.18.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
       "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+      "peer": true,
       "requires": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -23006,6 +23049,7 @@
       "version": "5.52.1",
       "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-5.52.1.tgz",
       "integrity": "sha512-fHA8+kXTbjagw3jkLiaS7KKrH8qe2DyOsiUhGlN4cdT77PEsfqXZl7ewDk1hsg+pJnPlnE50XtLxjR91iJOpmg==",
+      "peer": true,
       "requires": {
         "@algolia/abtesting": "1.18.1",
         "@algolia/client-abtesting": "5.52.1",
@@ -23283,6 +23327,7 @@
       "version": "4.28.2",
       "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz",
       "integrity": "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==",
+      "peer": true,
       "requires": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -23798,6 +23843,7 @@
           "version": "7.1.1",
           "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.1.tgz",
           "integrity": "sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==",
+          "peer": true,
           "requires": {
             "cssesc": "^3.0.0",
             "util-deprecate": "^1.0.2"
@@ -23965,7 +24011,8 @@
     "cytoscape": {
       "version": "3.33.3",
       "resolved": "https://registry.npmjs.org/cytoscape/-/cytoscape-3.33.3.tgz",
-      "integrity": "sha512-Gej7U+OKR+LZ8kvX7rb2HhCYJ0IhvEFsnkud4SB1PR+BUY/TsSO0dmOW59WEVLu51b1Rm+gQRKoz4bLYxGSZ2g=="
+      "integrity": "sha512-Gej7U+OKR+LZ8kvX7rb2HhCYJ0IhvEFsnkud4SB1PR+BUY/TsSO0dmOW59WEVLu51b1Rm+gQRKoz4bLYxGSZ2g==",
+      "peer": true
     },
     "cytoscape-cose-bilkent": {
       "version": "4.1.0",
@@ -24232,7 +24279,8 @@
     "d3-selection": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
-      "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ=="
+      "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
+      "peer": true
     },
     "d3-shape": {
       "version": "3.2.0",
@@ -24858,6 +24906,7 @@
           "version": "6.14.0",
           "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
           "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
+          "peer": true,
           "requires": {
             "fast-deep-equal": "^3.1.1",
             "fast-json-stable-stringify": "^2.0.0",
@@ -27284,6 +27333,7 @@
           "version": "6.15.0",
           "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
           "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
+          "peer": true,
           "requires": {
             "fast-deep-equal": "^3.1.1",
             "fast-json-stable-stringify": "^2.0.0",
@@ -27623,6 +27673,7 @@
       "version": "8.5.14",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.14.tgz",
       "integrity": "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==",
+      "peer": true,
       "requires": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -28055,6 +28106,7 @@
           "version": "7.1.1",
           "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.1.tgz",
           "integrity": "sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==",
+          "peer": true,
           "requires": {
             "cssesc": "^3.0.0",
             "util-deprecate": "^1.0.2"
@@ -28514,12 +28566,14 @@
     },
     "react": {
       "version": "18.3.1",
+      "peer": true,
       "requires": {
         "loose-envify": "^1.1.0"
       }
     },
     "react-dom": {
       "version": "18.3.1",
+      "peer": true,
       "requires": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -28549,6 +28603,7 @@
     },
     "react-loadable": {
       "version": "npm:@docusaurus/react-loadable@6.0.0",
+      "peer": true,
       "requires": {
         "@types/react": "*"
       }
@@ -28563,6 +28618,7 @@
     },
     "react-router": {
       "version": "5.3.4",
+      "peer": true,
       "requires": {
         "@babel/runtime": "^7.12.13",
         "history": "^4.9.0",
@@ -29581,7 +29637,8 @@
     "tslib": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "peer": true
     },
     "tsyringe": {
       "version": "4.10.0",
@@ -29633,7 +29690,8 @@
     },
     "typescript": {
       "version": "5.2.2",
-      "devOptional": true
+      "devOptional": true,
+      "peer": true
     },
     "ufo": {
       "version": "1.6.3",
@@ -29828,6 +29886,7 @@
           "version": "6.14.0",
           "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
           "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
+          "peer": true,
           "requires": {
             "fast-deep-equal": "^3.1.1",
             "fast-json-stable-stringify": "^2.0.0",
@@ -29935,6 +29994,7 @@
       "version": "5.105.2",
       "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.105.2.tgz",
       "integrity": "sha512-dRXm0a2qcHPUBEzVk8uph0xWSjV/xZxenQQbLwnwP7caQCYpqG1qddwlyEkIDkYn0K8tvmcrZ+bOrzoQ3HxCDw==",
+      "peer": true,
       "requires": {
         "@types/eslint-scope": "^3.7.7",
         "@types/estree": "^1.0.8",


### PR DESCRIPTION
## Rock Smash
Added a new page detailing the previously documented "unused" `/a/2/5/3` narc in HGSS based on decomp research.
Includes:
- step through of the Rock Smash logic: encounters and items.
- notes on the abilities that affect the encounter rates, item rates and item slots.
- updates to File Structure page to include the corrected use of the narc.