### PR TITLE
Fix the Pt Reusable Repels guide not using ReleaseAll

### DIFF
--- a/docs/generation-iv/guides/pt-reusable_repel/pt-reusable_repel.md
+++ b/docs/generation-iv/guides/pt-reusable_repel/pt-reusable_repel.md
@@ -192,7 +192,8 @@ Function 182:
 	Message 75
 	WaitButton
 	CloseMessage
-Return
+	ReleaseAll
+End
 
 Function 183:
 	AdrsValueSet 0x23DFF28 150
@@ -203,7 +204,8 @@ Function 183:
 	Message 75
 	WaitButton
 	CloseMessage
-Return
+	ReleaseAll
+End
 
 Function 184:
 	AdrsValueSet 0x23DFF28 250
@@ -214,7 +216,8 @@ Function 184:
 	Message 75
 	WaitButton
 	CloseMessage
-Return
+	ReleaseAll
+End
 ```
 
 </details>


### PR DESCRIPTION
Very small issue: When applying [this tutorial](https://ds-pokemon-hacking.github.io/docs/generation-iv/guides/pt-reusable_repel/), using a repel from the new menu does not run `ReleaseAll` before ending the script, unlike other branches where a repel is not used. This results in overworld objects being frozen until another script releases them, most noticeable if a Tag partner is following the player.